### PR TITLE
Cleanup LITE TransformerCache

### DIFF
--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
@@ -13,9 +13,9 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
     private static final byte[] NULL_BYTE_ARRAY = new byte[0];
 
     private final TransformerData data;
-    public final String transformerName;
-    public int runs = 0;
-    public int misses = 0;
+    private final String transformerName;
+    private int runs = 0;
+    private int misses = 0;
 
     public CachedTransformerWrapper(TransformerData data, String transformerName) {
         this.data = data;
@@ -70,5 +70,9 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
 
     private static byte[] fromNullableByteArray(byte[] array) {
         return array == NULL_BYTE_ARRAY ? null : array;
+    }
+
+    public String getProfileString() {
+        return transformerName + "," + runs + "," + misses;
     }
 }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
@@ -3,14 +3,14 @@ package makamys.coretweaks.optimization.transformercache.lite;
 import static makamys.coretweaks.optimization.transformercache.lite.TransformerCache.calculateHash;
 import static makamys.coretweaks.optimization.transformercache.lite.TransformerCache.nullSafeLength;
 
+import javax.annotation.Nonnull;
+
 import makamys.coretweaks.optimization.transformercache.lite.TransformerCache.TransformerData;
 import makamys.coretweaks.optimization.transformercache.lite.TransformerCache.TransformerData.CachedTransformation;
 import makamys.coretweaks.optimization.transformerproxy.ITransformerWrapper;
 import makamys.coretweaks.optimization.transformerproxy.TransformerProxy;
 
 public class CachedTransformerWrapper implements ITransformerWrapper {
-
-    private static final byte[] NULL_BYTE_ARRAY = new byte[0];
 
     private final TransformerData data;
     private final String transformerName;
@@ -24,6 +24,7 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
 
     @Override
     public byte[] wrapTransform(String name, String transformedName, byte[] basicClass, TransformerProxy proxy) {
+        if (basicClass == null) return null;
         runs++;
         byte[] result = this.getCached(transformedName, basicClass);
         if (result == null) {
@@ -31,16 +32,16 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
             result = proxy.invokeNextHandler(name, transformedName, basicClass);
             this.putCached(transformedName, basicClass, result != null ? result.clone() : null);
         }
-        return fromNullableByteArray(result);
+        return result;
     }
 
-    private byte[] getCached(String transformedName, byte[] basicClass) {
+    private byte[] getCached(String transformedName, @Nonnull byte[] basicClass) {
         CachedTransformation trans = this.data.transformationMap.get(transformedName);
         if (trans != null) {
             if (nullSafeLength(basicClass) == trans.preLength && calculateHash(basicClass) == trans.preHash) {
                 trans.updateAccessTime();
                 if (trans.postHash == trans.preHash) {
-                    return toNullableByteArray(basicClass);
+                    return basicClass;
                 }
                 byte[] result = trans.getNewClass(basicClass);
                 if (result == null) {
@@ -53,7 +54,7 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
         return null;
     }
 
-    private void putCached(String transformedName, byte[] basicClass, byte[] transformedBytes) {
+    private void putCached(String transformedName, @Nonnull byte[] basicClass, byte[] transformedBytes) {
         CachedTransformation cached = new CachedTransformation(
             transformedName,
             basicClass,
@@ -62,14 +63,6 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
         if (cached.isValid()) {
             this.data.transformationMap.put(transformedName, cached);
         }
-    }
-
-    private static byte[] toNullableByteArray(byte[] array) {
-        return array == null ? NULL_BYTE_ARRAY : array;
-    }
-
-    private static byte[] fromNullableByteArray(byte[] array) {
-        return array == NULL_BYTE_ARRAY ? null : array;
     }
 
     public String getProfileString() {

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
@@ -7,7 +7,7 @@ import makamys.coretweaks.optimization.transformerproxy.TransformerProxy;
 
 public class CachedTransformerWrapper implements ITransformerWrapper {
 
-    private final String transformerName;
+    public final String transformerName;
     public int runs = 0;
     public int misses = 0;
 
@@ -24,7 +24,7 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
             misses++;
             result = proxy.invokeNextHandler(name, transformedName, basicClass);
             TransformerCache.instance
-                .putCached(transformerName, name, transformedName, basicClass, result != null ? result.clone() : null);
+                .putCached(transformerName, transformedName, basicClass, result != null ? result.clone() : null);
         }
         return TransformerCache.fromNullableByteArray(result);
     }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
@@ -1,8 +1,5 @@
 package makamys.coretweaks.optimization.transformercache.lite;
 
-import static makamys.coretweaks.optimization.transformercache.lite.TransformerCache.calculateHash;
-import static makamys.coretweaks.optimization.transformercache.lite.TransformerCache.nullSafeLength;
-
 import javax.annotation.Nonnull;
 
 import makamys.coretweaks.optimization.transformercache.lite.TransformerCache.TransformerData;
@@ -36,20 +33,18 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
     }
 
     private byte[] getCached(String transformedName, @Nonnull byte[] basicClass) {
-        CachedTransformation trans = this.data.transformationMap.get(transformedName);
-        if (trans != null) {
-            if (nullSafeLength(basicClass) == trans.preLength && calculateHash(basicClass) == trans.preHash) {
-                trans.updateAccessTime();
-                if (trans.postHash == trans.preHash) {
-                    return basicClass;
-                }
-                byte[] result = trans.getNewClass(basicClass);
-                if (result == null) {
-                    this.data.transformationMap.remove(transformedName);
-                    return null;
-                }
-                return result;
+        CachedTransformation cached = this.data.transformationMap.get(transformedName);
+        if (cached != null && cached.basicClassMatches(basicClass)) {
+            cached.updateAccessTime();
+            if (cached.preHash == cached.postHash) {
+                return basicClass;
             }
+            byte[] result = cached.getNewClass(basicClass);
+            if (result == null) {
+                this.data.transformationMap.remove(transformedName);
+                return null;
+            }
+            return result;
         }
         return null;
     }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
@@ -1,5 +1,7 @@
 package makamys.coretweaks.optimization.transformercache.lite;
 
+import java.util.Map;
+
 import javax.annotation.Nonnull;
 
 import makamys.coretweaks.optimization.transformercache.lite.TransformerCache.TransformerData;
@@ -13,6 +15,7 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
     private final String transformerName;
     private int runs = 0;
     private int misses = 0;
+    private volatile boolean stopped = false;
 
     public CachedTransformerWrapper(TransformerData data, String transformerName) {
         this.data = data;
@@ -22,18 +25,23 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
     @Override
     public byte[] wrapTransform(String name, String transformedName, byte[] basicClass, TransformerProxy proxy) {
         if (basicClass == null) return null;
+        if (this.stopped) {
+            return proxy.invokeNextHandler(name, transformedName, basicClass);
+        }
         runs++;
-        byte[] result = this.getCached(transformedName, basicClass);
+        final Map<String, CachedTransformation> map = this.data.transformationMap;
+        byte[] result = getCached(map, transformedName, basicClass);
         if (result == null) {
             misses++;
             result = proxy.invokeNextHandler(name, transformedName, basicClass);
-            this.putCached(transformedName, basicClass, result != null ? result.clone() : null);
+            putCached(map, transformedName, basicClass, result != null ? result.clone() : null);
         }
         return result;
     }
 
-    private byte[] getCached(String transformedName, @Nonnull byte[] basicClass) {
-        CachedTransformation cached = this.data.transformationMap.get(transformedName);
+    private static byte[] getCached(Map<String, CachedTransformation> map, String transformedName,
+        @Nonnull byte[] basicClass) {
+        CachedTransformation cached = map.get(transformedName);
         if (cached != null && cached.basicClassMatches(basicClass)) {
             cached.updateAccessTime();
             if (!cached.isDiff()) {
@@ -41,7 +49,7 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
             }
             byte[] transformedBytes = cached.getTransformedBytes(basicClass);
             if (transformedBytes == null) {
-                this.data.transformationMap.remove(transformedName);
+                map.remove(transformedName);
                 return null;
             }
             return transformedBytes;
@@ -49,14 +57,19 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
         return null;
     }
 
-    private void putCached(String transformedName, @Nonnull byte[] basicClass, byte[] transformedBytes) {
+    private static void putCached(Map<String, CachedTransformation> map, String transformedName,
+        @Nonnull byte[] basicClass, byte[] transformedBytes) {
         CachedTransformation cached = new CachedTransformation(transformedName, basicClass, transformedBytes);
         if (cached.isValid()) {
-            this.data.transformationMap.put(transformedName, cached);
+            map.put(transformedName, cached);
         }
     }
 
     public String getProfileString() {
         return transformerName + "," + runs + "," + misses;
+    }
+
+    public void stopTransformer() {
+        this.stopped = true;
     }
 }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
@@ -1,31 +1,74 @@
 package makamys.coretweaks.optimization.transformercache.lite;
 
-import net.minecraft.launchwrapper.IClassTransformer;
+import static makamys.coretweaks.optimization.transformercache.lite.TransformerCache.calculateHash;
+import static makamys.coretweaks.optimization.transformercache.lite.TransformerCache.nullSafeLength;
 
+import makamys.coretweaks.optimization.transformercache.lite.TransformerCache.TransformerData;
+import makamys.coretweaks.optimization.transformercache.lite.TransformerCache.TransformerData.CachedTransformation;
 import makamys.coretweaks.optimization.transformerproxy.ITransformerWrapper;
 import makamys.coretweaks.optimization.transformerproxy.TransformerProxy;
 
 public class CachedTransformerWrapper implements ITransformerWrapper {
 
+    private static final byte[] NULL_BYTE_ARRAY = new byte[0];
+
+    private final TransformerData data;
     public final String transformerName;
     public int runs = 0;
     public int misses = 0;
 
-    public CachedTransformerWrapper(IClassTransformer original) {
-        this.transformerName = original.getClass()
-            .getCanonicalName();
+    public CachedTransformerWrapper(TransformerData data, String transformerName) {
+        this.data = data;
+        this.transformerName = transformerName;
     }
 
     @Override
     public byte[] wrapTransform(String name, String transformedName, byte[] basicClass, TransformerProxy proxy) {
         runs++;
-        byte[] result = TransformerCache.instance.getCached(transformerName, transformedName, basicClass);
+        byte[] result = this.getCached(transformedName, basicClass);
         if (result == null) {
             misses++;
             result = proxy.invokeNextHandler(name, transformedName, basicClass);
-            TransformerCache.instance
-                .putCached(transformerName, transformedName, basicClass, result != null ? result.clone() : null);
+            this.putCached(transformedName, basicClass, result != null ? result.clone() : null);
         }
-        return TransformerCache.fromNullableByteArray(result);
+        return fromNullableByteArray(result);
+    }
+
+    private byte[] getCached(String transformedName, byte[] basicClass) {
+        CachedTransformation trans = this.data.transformationMap.get(transformedName);
+        if (trans != null) {
+            if (nullSafeLength(basicClass) == trans.preLength && calculateHash(basicClass) == trans.preHash) {
+                trans.updateAccessTime();
+                if (trans.postHash == trans.preHash) {
+                    return toNullableByteArray(basicClass);
+                }
+                byte[] result = trans.getNewClass(basicClass);
+                if (result == null) {
+                    this.data.transformationMap.remove(transformedName);
+                    return null;
+                }
+                return result;
+            }
+        }
+        return null;
+    }
+
+    private void putCached(String transformedName, byte[] basicClass, byte[] transformedBytes) {
+        CachedTransformation cached = new CachedTransformation(
+            transformedName,
+            basicClass,
+            nullSafeLength(basicClass),
+            transformedBytes);
+        if (cached.isValid()) {
+            this.data.transformationMap.put(transformedName, cached);
+        }
+    }
+
+    private static byte[] toNullableByteArray(byte[] array) {
+        return array == null ? NULL_BYTE_ARRAY : array;
+    }
+
+    private static byte[] fromNullableByteArray(byte[] array) {
+        return array == NULL_BYTE_ARRAY ? null : array;
     }
 }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
@@ -55,11 +55,7 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
     }
 
     private void putCached(String transformedName, @Nonnull byte[] basicClass, byte[] transformedBytes) {
-        CachedTransformation cached = new CachedTransformation(
-            transformedName,
-            basicClass,
-            nullSafeLength(basicClass),
-            transformedBytes);
+        CachedTransformation cached = new CachedTransformation(transformedName, basicClass, transformedBytes);
         if (cached.isValid()) {
             this.data.transformationMap.put(transformedName, cached);
         }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
@@ -36,15 +36,15 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
         CachedTransformation cached = this.data.transformationMap.get(transformedName);
         if (cached != null && cached.basicClassMatches(basicClass)) {
             cached.updateAccessTime();
-            if (cached.preHash == cached.postHash) {
+            if (!cached.isDiff()) {
                 return basicClass;
             }
-            byte[] result = cached.getNewClass(basicClass);
-            if (result == null) {
+            byte[] transformedBytes = cached.getTransformedBytes(basicClass);
+            if (transformedBytes == null) {
                 this.data.transformationMap.remove(transformedName);
                 return null;
             }
-            return result;
+            return transformedBytes;
         }
         return null;
     }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/CachedTransformerWrapper.java
@@ -7,6 +7,7 @@ import makamys.coretweaks.optimization.transformerproxy.TransformerProxy;
 
 public class CachedTransformerWrapper implements ITransformerWrapper {
 
+    private final String transformerName;
     public int runs = 0;
     public int misses = 0;
 
@@ -15,12 +16,10 @@ public class CachedTransformerWrapper implements ITransformerWrapper {
             .getCanonicalName();
     }
 
-    private final String transformerName;
-
     @Override
     public byte[] wrapTransform(String name, String transformedName, byte[] basicClass, TransformerProxy proxy) {
         runs++;
-        byte[] result = TransformerCache.instance.getCached(transformerName, name, transformedName, basicClass);
+        byte[] result = TransformerCache.instance.getCached(transformerName, transformedName, basicClass);
         if (result == null) {
             misses++;
             result = proxy.invokeNextHandler(name, transformedName, basicClass);

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.launchwrapper.IClassTransformer;
 import net.minecraft.launchwrapper.Launch;
@@ -361,14 +363,14 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                 return diff != INVALID_RESULT;
             }
 
-            public CachedTransformation(String targetClassName, byte[] source, int sourceLen, byte[] target) {
+            public CachedTransformation(String targetClassName, @Nonnull byte[] basicClass, byte[] transformedBytes) {
                 this.targetClassName = targetClassName;
-                this.preHash = calculateHash(source, sourceLen);
-                this.preLength = sourceLen;
-                this.postLength = nullSafeLength(target);
-                this.postHash = calculateHash(target);
+                this.preLength = nullSafeLength(basicClass);
+                this.preHash = calculateHash(basicClass, this.preLength);
+                this.postLength = nullSafeLength(transformedBytes);
+                this.postHash = calculateHash(transformedBytes);
                 if (preHash != postHash) {
-                    diff = generateDiff(source, sourceLen, target, targetClassName);
+                    diff = generateDiff(basicClass, this.preLength, transformedBytes, targetClassName);
                 }
                 this.updateAccessTime();
             }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -330,7 +330,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         boolean enableDiffs = Config.useDiffsInTransformerCache;
     }
 
-    public static class TransformerData {
+    public final static class TransformerData {
 
         String transformerClassName;
         Map<String, CachedTransformation> transformationMap = new ConcurrentHashMap<>();
@@ -342,7 +342,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         @SuppressWarnings("unused")
         public TransformerData() {}
 
-        public static class CachedTransformation {
+        public final static class CachedTransformation {
 
             private static final byte[] INVALID_RESULT = new byte[] {};
 
@@ -353,31 +353,65 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
             int preHash;
             int postLength;
             int postHash;
+            /**
+             * This field is the actual diff if the enableDiffs config is enabled, otherwise it's the whole output class
+             */
             byte[] diff;
             int lastAccessed;
 
             @SuppressWarnings("unused")
             public CachedTransformation() {}
 
-            public boolean isValid() {
-                return diff != INVALID_RESULT;
-            }
-
             public CachedTransformation(String targetClassName, @Nonnull byte[] basicClass, byte[] transformedBytes) {
                 this.targetClassName = targetClassName;
-                this.preLength = nullSafeLength(basicClass);
-                this.preHash = calculateHash(basicClass, this.preLength);
+                this.preLength = basicClass.length;
+                this.preHash = calculateHash(basicClass, basicClass.length);
                 this.postLength = nullSafeLength(transformedBytes);
-                this.postHash = calculateHash(transformedBytes);
+                this.postHash = calculateHash(transformedBytes, this.postLength);
                 if (preHash != postHash) {
                     diff = generateDiff(basicClass, this.preLength, transformedBytes, targetClassName);
                 }
                 this.updateAccessTime();
             }
 
+            public boolean isValid() {
+                return diff != INVALID_RESULT;
+            }
+
             public void updateAccessTime() {
                 // TODO update the format in 6055
                 this.lastAccessed = (int) (System.currentTimeMillis() / 1000 / 60);
+            }
+
+            public boolean basicClassMatches(@Nonnull byte[] basicClass) {
+                return basicClass.length == this.preLength
+                    && calculateHash(basicClass, basicClass.length) == this.preHash;
+            }
+
+            @SuppressWarnings("UnstableApiUsage")
+            public byte[] getNewClass(byte[] source) {
+                if (source == null || !TransformerCache.instance.meta.enableDiffs) {
+                    return diff;
+                }
+                byte[] newClass = new byte[postLength];
+                try {
+                    InMemoryGDiffPatcher.patch(source, diff, newClass);
+                } catch (Exception e) {
+                    LOGGER.warn("Failed to apply cached diff for {}, discarding entry", targetClassName);
+                    return null;
+                }
+                int actualHash = Hashing.adler32()
+                    .hashBytes(newClass)
+                    .asInt();
+                if (actualHash != postHash) {
+                    LOGGER.warn("Hash mismatch after applying cached diff for {}, discarding entry", targetClassName);
+                    return null;
+                }
+                return newClass;
+            }
+
+            public int getEstimatedSize() {
+                return targetClassName.length() + 4 + 4 + 4 + (diff != null ? diff.length : 0) + 4;
             }
 
             private static final ThreadLocal<Delta> deltaThreadLocal = ThreadLocal.withInitial(Delta::new);
@@ -410,32 +444,6 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                 }
                 diffErrors++;
                 return INVALID_RESULT;
-            }
-
-            @SuppressWarnings("UnstableApiUsage")
-            public byte[] getNewClass(byte[] source) {
-                if (source == null || !TransformerCache.instance.meta.enableDiffs) {
-                    return diff;
-                }
-                byte[] newClass = new byte[postLength];
-                try {
-                    InMemoryGDiffPatcher.patch(source, diff, newClass);
-                } catch (Exception e) {
-                    LOGGER.warn("Failed to apply cached diff for {}, discarding entry", targetClassName);
-                    return null;
-                }
-                int actualHash = Hashing.adler32()
-                    .hashBytes(newClass)
-                    .asInt();
-                if (actualHash != postHash) {
-                    LOGGER.warn("Hash mismatch after applying cached diff for {}, discarding entry", targetClassName);
-                    return null;
-                }
-                return newClass;
-            }
-
-            public int getEstimatedSize() {
-                return targetClassName.length() + 4 + 4 + 4 + (diff != null ? diff.length : 0) + 4;
             }
         }
     }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -293,12 +293,8 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         }
     }
 
-    public static int nullSafeLength(byte[] array) {
+    private static int nullSafeLength(byte[] array) {
         return array == null ? -1 : array.length;
-    }
-
-    public static int calculateHash(byte[] data) {
-        return calculateHash(data, nullSafeLength(data));
     }
 
     private static final ThreadLocal<HashMemo> memoizedHash = ThreadLocal.withInitial(HashMemo::new);
@@ -307,6 +303,10 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
 
         byte[] data;
         int value;
+    }
+
+    private static int calculateHash(byte[] data) {
+        return calculateHash(data, nullSafeLength(data));
     }
 
     @SuppressWarnings("UnstableApiUsage")

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -137,7 +137,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         kryo.register(byte[].class);
 
         if (DAT_OLD.exists() && !DAT.exists()) {
-            LOGGER.info("Migrating class cache: " + DAT_OLD + " -> " + DAT);
+            LOGGER.info("Migrating class cache: {} -> {}", DAT_OLD, DAT);
             DAT_OLD.renameTo(DAT);
         }
 
@@ -170,21 +170,17 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                 e.printStackTrace();
             } catch (Exception e) {
                 CoreTweaks.LOGGER.error(
-                    "There was an error reading the transformer cache. A new one will be created. The previous one has been saved as "
-                        + DAT_ERRORED.getName()
-                        + " for inspection.");
+                    "There was an error reading the transformer cache. A new one will be created. The previous one has been saved as {} for inspection.",
+                    DAT_ERRORED.getName());
                 DAT.renameTo(DAT_ERRORED);
                 e.printStackTrace();
             }
             long t1 = System.nanoTime();
-            LOGGER.debug(
-                "Loaded lite transformer cache with " + getSize()
-                    + " entries in "
-                    + ((t1 - t0) / 1_000_000_000.0)
-                    + "s");
+            LOGGER
+                .debug("Loaded lite transformer cache with {} entries in {}s", getSize(), (t1 - t0) / 1_000_000_000.0);
         } else {
             long t1 = System.nanoTime();
-            LOGGER.debug("Created new lite transformer cache in " + ((t1 - t0) / 1_000_000_000.0) + "s");
+            LOGGER.debug("Created new lite transformer cache in {}s", (t1 - t0) / 1_000_000_000.0);
         }
     }
 
@@ -328,7 +324,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         }
     }
 
-    public byte[] getCached(String transName, String name, String transformedName, byte[] basicClass) {
+    public byte[] getCached(String transName, String transformedName, byte[] basicClass) {
         TransformerData transData = transformerMap.get(transName);
         if (transData != null) {
             CachedTransformation trans = transData.transformationMap.get(transformedName);
@@ -380,11 +376,12 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         }
     }
 
-    public static int calculateHash(byte[] data) {
+    private static int calculateHash(byte[] data) {
         return calculateHash(data, nullSafeLength(data));
     }
 
-    public static int calculateHash(byte[] data, int len) {
+    @SuppressWarnings("UnstableApiUsage")
+    private static int calculateHash(byte[] data, int len) {
         HashMemo memo = memoizedHash.get();
         if (data == memo.data) {
             return memo.value;
@@ -469,18 +466,20 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                     // nothome delta library uses interruptible channels which throw an error if the thread gets
                     // interrupted.
                     // No big deal, it's a race condition so it probably won't happen next time.
-                    LOGGER.debug("Failed to generate diff for class " + name + ", thread was interrupted.");
+                    LOGGER.debug("Failed to generate diff for class {}, thread was interrupted.", name);
                 } catch (Exception e) {
                     // Unknown exception. We want to know more about this, but it's not worth crashing over if it's a
                     // rare issue.
                     LOGGER.error(
-                        "Failed to generate diff for class " + name + ". Please report this if it keeps happening!");
-                    e.printStackTrace();
+                        "Failed to generate diff for class {}. Please report this if it keeps happening!",
+                        name,
+                        e);
                 }
                 diffErrors++;
                 return INVALID_RESULT;
             }
 
+            @SuppressWarnings("UnstableApiUsage")
             public byte[] getNewClass(byte[] source) {
                 if (source == null || !TransformerCache.instance.meta.enableDiffs) {
                     return diff;

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -170,25 +170,6 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
             .sum();
     }
 
-    private void persistCache() {
-        if (savedAndCleared) {
-            return;
-        }
-        if (CachedTransformation.diffErrors > 0) {
-            logger().warn(
-                "{} entries have errored. Please report this if it keeps happening!",
-                CachedTransformation.diffErrors);
-        }
-        try {
-            final long l = System.currentTimeMillis();
-            saveTransformerCache();
-            saveProfilingResults();
-            logger().info("Saved transformer cache in {}ms", (System.currentTimeMillis() - l));
-        } catch (IOException e) {
-            logger().error("Error saving lite transformer cache", e);
-        }
-    }
-
     private int clientTicks;
 
     @SideOnly(Side.CLIENT)
@@ -229,6 +210,25 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
     @Override
     public void onShutdown() {
         persistCache();
+    }
+
+    private void persistCache() {
+        if (savedAndCleared) {
+            return;
+        }
+        if (CachedTransformation.diffErrors > 0) {
+            logger().warn(
+                "{} entries have errored. Please report this if it keeps happening!",
+                CachedTransformation.diffErrors);
+        }
+        try {
+            final long l = System.currentTimeMillis();
+            saveTransformerCache();
+            saveProfilingResults();
+            logger().info("Saved transformer cache in {}ms", (System.currentTimeMillis() - l));
+        } catch (IOException e) {
+            logger().error("Error saving lite transformer cache", e);
+        }
     }
 
     private void saveTransformerCache() throws IOException {

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -16,6 +16,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedByInterruptException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -33,7 +34,6 @@ import com.esotericsoftware.kryo.kryo5.io.Input;
 import com.esotericsoftware.kryo.kryo5.io.Output;
 import com.esotericsoftware.kryo.kryo5.unsafe.UnsafeInput;
 import com.esotericsoftware.kryo.kryo5.unsafe.UnsafeOutput;
-import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
 
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -67,46 +67,33 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
 
     public static final TransformerCache instance = new TransformerCache();
 
-    private final List<CachedTransformerWrapper> myTransformers = new ArrayList<>();
-    private final Map<String, TransformerData> transformerMap = new ConcurrentHashMap<>();
-    private final CacheMeta meta = new CacheMeta();
+    private static final byte[] NULL_BYTE_ARRAY = new byte[0];
 
     private static final byte MAGIC_0 = 0;
     private static final byte VERSION = 3;
 
-    private static final File DAT_OLD = Util.childFile(CoreTweaks.CACHE_DIR, "transformerCache.dat");
-    private static final File DAT = Util.childFile(CoreTweaks.CACHE_DIR, "classTransformerLite.cache");
-    private static final File DAT_ERRORED = Util.childFile(CoreTweaks.CACHE_DIR, "classTransformerLite.cache.errored");
-    private static final File TRANSFORMERCACHE_PROFILER_CSV = Util
-        .childFile(CoreTweaks.OUT_DIR, "transformercache_profiler.csv");
-    private Kryo kryo;
+    private final List<CachedTransformerWrapper> myTransformers = new ArrayList<>();
+    private final Map<String, TransformerData> transformerMap = new ConcurrentHashMap<>();
+    private final CacheMeta meta = new CacheMeta();
 
-    private static final ThreadLocal<Delta> deltaThreadLocal = ThreadLocal.withInitial(Delta::new);
+    private final File DAT_OLD = Util.childFile(CoreTweaks.CACHE_DIR, "transformerCache.dat");
+    private final File DAT = Util.childFile(CoreTweaks.CACHE_DIR, "classTransformerLite.cache");
+    private final File DAT_ERRORED = Util.childFile(CoreTweaks.CACHE_DIR, "classTransformerLite.cache.errored");
+    private final File CACHE_PROFILER_CSV = Util.childFile(CoreTweaks.OUT_DIR, "transformercache_profiler.csv");
+    private final Kryo kryo = new Kryo();
 
-    private static final byte[] NULL_BYTE_ARRAY = new byte[0];
-
-    private Set<String> transformersToCache = new HashSet<>();
+    private final Set<String> transformersToCache = new HashSet<>();
 
     private volatile boolean savedAndCleared = false;
 
-    private static class HashMemo {
-
-        byte[] data;
-        int value;
-    }
-
-    private static final ThreadLocal<HashMemo> memoizedHash = ThreadLocal.withInitial(HashMemo::new);
+    private TransformerCache() {}
 
     public void init(boolean late) {
-
-        transformersToCache = Sets.newHashSet(Config.transformersToCache.get());
-
+        Collections.addAll(transformersToCache, Config.transformersToCache.get());
         // We get a ClassCircularityError if we don't add these
         Launch.classLoader.addTransformerExclusion("makamys.coretweaks.util.InMemoryGDiffPatcher");
         Launch.classLoader.addTransformerExclusion("makamys.coretweaks.util.FastByteBufferSeekableSource");
-
         loadData();
-
         TransformerProxyManager.instance.addAdditionListener(this, !late);
     }
 
@@ -127,7 +114,6 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
     private void loadData() {
         long t0 = System.nanoTime();
 
-        kryo = new Kryo();
         kryo.register(TransformerCache.CacheMeta.class);
         kryo.register(ConcurrentHashMap.class);
         kryo.register(TransformerCache.TransformerData.class);
@@ -160,7 +146,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                     if (!Arrays.asList(Config.transformersToCache.get())
                         .contains(e.getKey())) {
                         CoreTweaks.LOGGER
-                            .info("Dropping " + e.getKey() + " from cache because we don't care about it anymore.");
+                            .info("Dropping {} from cache because we don't care about it anymore.", e.getKey());
                         it.remove();
                     }
                 }
@@ -240,7 +226,6 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
             persistCache();
             transformerMap.clear();
             myTransformers.clear();
-            memoizedHash.remove();
             savedAndCleared = true;
         }
         LOGGER.info("Lite transformer cache saved and cleared from memory");
@@ -305,7 +290,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
     }
 
     private void saveProfilingResults() throws IOException {
-        try (FileWriter fw = new FileWriter(TRANSFORMERCACHE_PROFILER_CSV)) {
+        try (FileWriter fw = new FileWriter(CACHE_PROFILER_CSV)) {
             fw.write("transformer,runs,misses\n");
             for (CachedTransformerWrapper transformer : myTransformers) {
                 final String name = transformer.transformerName;
@@ -371,13 +356,21 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         return calculateHash(data, nullSafeLength(data));
     }
 
+    private static final ThreadLocal<HashMemo> memoizedHash = ThreadLocal.withInitial(HashMemo::new);
+
+    private static class HashMemo {
+
+        byte[] data;
+        int value;
+    }
+
     @SuppressWarnings("UnstableApiUsage")
     private static int calculateHash(byte[] data, int len) {
-        HashMemo memo = memoizedHash.get();
+        final HashMemo memo = memoizedHash.get();
         if (data == memo.data) {
             return memo.value;
         }
-        int hash = data == null ? -1
+        final int hash = data == null ? -1
             : Hashing.adler32()
                 .hashBytes(data, 0, len)
                 .asInt();
@@ -406,6 +399,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
             this.transformerClassName = transformerClassName;
         }
 
+        @SuppressWarnings("unused")
         public TransformerData() {}
 
         public static class CachedTransformation {
@@ -422,6 +416,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
             byte[] diff;
             int lastAccessed;
 
+            @SuppressWarnings("unused")
             public CachedTransformation() {}
 
             public boolean isValid() {
@@ -439,6 +434,8 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                 }
                 this.lastAccessed = now();
             }
+
+            private static final ThreadLocal<Delta> deltaThreadLocal = ThreadLocal.withInitial(Delta::new);
 
             private static byte[] generateDiff(byte[] source, int sourceLen, byte[] target, String name) {
                 if (source == null || !TransformerCache.instance.meta.enableDiffs) {
@@ -479,15 +476,14 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                 try {
                     InMemoryGDiffPatcher.patch(source, diff, newClass);
                 } catch (Exception e) {
-                    LOGGER.warn("Failed to apply cached diff for " + targetClassName + ", discarding entry");
+                    LOGGER.warn("Failed to apply cached diff for {}, discarding entry", targetClassName);
                     return null;
                 }
                 int actualHash = Hashing.adler32()
                     .hashBytes(newClass)
                     .asInt();
                 if (actualHash != postHash) {
-                    LOGGER
-                        .warn("Hash mismatch after applying cached diff for " + targetClassName + ", discarding entry");
+                    LOGGER.warn("Hash mismatch after applying cached diff for {}, discarding entry", targetClassName);
                     return null;
                 }
                 return newClass;

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -156,10 +156,10 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
             }
             long t1 = System.nanoTime();
             LOGGER
-                .debug("Loaded lite transformer cache with {} entries in {}s", getSize(), (t1 - t0) / 1_000_000_000.0);
+                .info("Loaded lite transformer cache with {} entries in {}s", getSize(), (t1 - t0) / 1_000_000_000.0);
         } else {
             long t1 = System.nanoTime();
-            LOGGER.debug("Created new lite transformer cache in {}s", (t1 - t0) / 1_000_000_000.0);
+            LOGGER.info("Created new lite transformer cache in {}s", (t1 - t0) / 1_000_000_000.0);
         }
     }
 

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -286,10 +286,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         try (FileWriter fw = new FileWriter(CACHE_PROFILER_CSV)) {
             fw.write("transformer,runs,misses\n");
             for (CachedTransformerWrapper transformer : myTransformers) {
-                final String name = transformer.transformerName;
-                final int runs = transformer.runs;
-                final int misses = transformer.misses;
-                fw.write(name + "," + runs + "," + misses + "\n");
+                fw.write(transformer.getProfileString() + "\n");
             }
         }
     }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -368,10 +368,14 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                 this.preHash = calculateHash(basicClass, basicClass.length);
                 this.postLength = nullSafeLength(transformedBytes);
                 this.postHash = calculateHash(transformedBytes, this.postLength);
-                if (preHash != postHash) {
+                if (isDiff()) {
                     diff = generateDiff(basicClass, this.preLength, transformedBytes, targetClassName);
                 }
                 this.updateAccessTime();
+            }
+
+            public boolean isDiff() {
+                return preHash != postHash;
             }
 
             public boolean isValid() {
@@ -389,7 +393,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
             }
 
             @SuppressWarnings("UnstableApiUsage")
-            public byte[] getNewClass(byte[] source) {
+            public byte[] getTransformedBytes(byte[] source) {
                 if (source == null || !TransformerCache.instance.meta.enableDiffs) {
                     return diff;
                 }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -308,18 +308,12 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
 
     private void saveProfilingResults() throws IOException {
         try (FileWriter fw = new FileWriter(TRANSFORMERCACHE_PROFILER_CSV)) {
-            fw.write("class,name,runs,misses\n");
+            fw.write("transformer,runs,misses\n");
             for (CachedTransformerWrapper transformer : myTransformers) {
-                String className = transformer.getClass()
-                    .getCanonicalName();
-                String name = transformer.toString();
-                int runs = 0;
-                int misses = 0;
-                if (transformer instanceof CachedTransformerWrapper) {
-                    runs = transformer.runs;
-                    misses = transformer.misses;
-                }
-                fw.write(className + "," + name + "," + runs + "," + misses + "\n");
+                final String name = transformer.transformerName;
+                final int runs = transformer.runs;
+                final int misses = transformer.misses;
+                fw.write(name + "," + runs + "," + misses + "\n");
             }
         }
     }
@@ -358,8 +352,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         return array == null ? -1 : array.length;
     }
 
-    public void putCached(String transName, String name, String transformedName, byte[] preTransformBytes,
-        byte[] result) {
+    public void putCached(String transName, String transformedName, byte[] preTransformBytes, byte[] result) {
         synchronized (transformerMap) {
             TransformerData data = transformerMap.get(transName);
             if (data == null) {

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -119,7 +119,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                 .getCanonicalName())) {
             CachedTransformerWrapper proxy = new CachedTransformerWrapper(transformer);
             myTransformers.add(proxy);
-            return new CachedTransformerWrapper(transformer);
+            return proxy;
         } else {
             return null;
         }

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -15,13 +15,10 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedByInterruptException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -139,17 +136,15 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                     transformerMap.putAll(kryo.readObject(is, ConcurrentHashMap.class));
                 }
 
-                Iterator<Entry<String, TransformerData>> it = transformerMap.entrySet()
-                    .iterator();
-                while (it.hasNext()) {
-                    Entry<String, TransformerData> e = it.next();
-                    if (!Arrays.asList(Config.transformersToCache.get())
-                        .contains(e.getKey())) {
-                        CoreTweaks.LOGGER
-                            .info("Dropping {} from cache because we don't care about it anymore.", e.getKey());
-                        it.remove();
-                    }
-                }
+                transformerMap.entrySet()
+                    .removeIf(e -> {
+                        if (!transformersToCache.contains(e.getKey())) {
+                            CoreTweaks.LOGGER
+                                .info("Dropping {} from cache because we don't care about it anymore.", e.getKey());
+                            return true;
+                        }
+                        return false;
+                    });
             } catch (IOException e) {
                 e.printStackTrace();
             } catch (Exception e) {

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -77,11 +77,11 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
     private final File DAT = Util.childFile(CoreTweaks.CACHE_DIR, "classTransformerLite.cache");
     private final File DAT_ERRORED = Util.childFile(CoreTweaks.CACHE_DIR, "classTransformerLite.cache.errored");
     private final File CACHE_PROFILER_CSV = Util.childFile(CoreTweaks.OUT_DIR, "transformercache_profiler.csv");
-    private final Kryo kryo = new Kryo();
+    private Kryo kryo;
 
     private final Set<String> transformersToCache = new HashSet<>();
 
-    private volatile boolean savedAndCleared = false;
+    private volatile boolean stoppedTransformer = false;
 
     private TransformerCache() {}
 
@@ -112,6 +112,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
     private void loadData() {
         long t0 = System.nanoTime();
 
+        kryo = new Kryo();
         kryo.register(TransformerCache.CacheMeta.class);
         kryo.register(ConcurrentHashMap.class);
         kryo.register(TransformerCache.TransformerData.class);
@@ -194,28 +195,28 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         freeCacheDuringRuntime();
     }
 
-    private void freeCacheDuringRuntime() {
-        synchronized (transformerMap) {
-            if (savedAndCleared) {
-                return;
-            }
-            persistCache();
-            transformerMap.clear();
-            myTransformers.clear();
-            savedAndCleared = true;
+    private synchronized void freeCacheDuringRuntime() {
+        if (stoppedTransformer) {
+            return;
         }
+        stoppedTransformer = true;
+        myTransformers.forEach(CachedTransformerWrapper::stopTransformer);
+        saveCache();
+        transformerMap.values()
+            .forEach(t -> t.transformationMap = Collections.emptyMap());
+        transformerMap.clear();
         LOGGER.info("Lite transformer cache saved and cleared from memory");
     }
 
     @Override
     public void onShutdown() {
-        persistCache();
-    }
-
-    private void persistCache() {
-        if (savedAndCleared) {
+        if (stoppedTransformer) {
             return;
         }
+        saveCache();
+    }
+
+    private void saveCache() {
         if (CachedTransformation.diffErrors > 0) {
             logger().warn(
                 "{} entries have errored. Please report this if it keeps happening!",
@@ -245,6 +246,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
             kryo.writeObject(output, meta);
             kryo.writeObject(output, transformerMap);
         }
+        kryo = null;
     }
 
     private void trimCache(long maxSize) {

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -64,8 +64,6 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
 
     public static final TransformerCache instance = new TransformerCache();
 
-    private static final byte[] NULL_BYTE_ARRAY = new byte[0];
-
     private static final byte MAGIC_0 = 0;
     private static final byte VERSION = 3;
 
@@ -96,10 +94,11 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
 
     @Override
     public ITransformerWrapper wrap(IClassTransformer transformer) {
-        if (transformersToCache.contains(
-            transformer.getClass()
-                .getCanonicalName())) {
-            CachedTransformerWrapper proxy = new CachedTransformerWrapper(transformer);
+        final String transName = transformer.getClass()
+            .getCanonicalName();
+        if (transformersToCache.contains(transName)) {
+            final TransformerData data = transformerMap.computeIfAbsent(transName, TransformerData::new);
+            final CachedTransformerWrapper proxy = new CachedTransformerWrapper(data, transName);
             myTransformers.add(proxy);
             return proxy;
         } else {
@@ -155,8 +154,7 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                 e.printStackTrace();
             }
             long t1 = System.nanoTime();
-            LOGGER
-                .info("Loaded lite transformer cache with {} entries in {}s", getSize(), (t1 - t0) / 1_000_000_000.0);
+            LOGGER.info("Loaded lite transformer cache with {} entries in {}s", getSize(), (t1 - t0) / 1_000_000_000.0);
         } else {
             long t1 = System.nanoTime();
             LOGGER.info("Created new lite transformer cache in {}s", (t1 - t0) / 1_000_000_000.0);
@@ -296,58 +294,11 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         }
     }
 
-    public byte[] getCached(String transName, String transformedName, byte[] basicClass) {
-        TransformerData transData = transformerMap.get(transName);
-        if (transData != null) {
-            CachedTransformation trans = transData.transformationMap.get(transformedName);
-            if (trans != null) {
-                if (nullSafeLength(basicClass) == trans.preLength && calculateHash(basicClass) == trans.preHash) {
-                    trans.lastAccessed = now();
-                    if (trans.postHash == trans.preHash) {
-                        return toNullableByteArray(basicClass);
-                    }
-                    byte[] result = trans.getNewClass(basicClass);
-                    if (result == null) {
-                        transData.transformationMap.remove(transformedName);
-                        return null;
-                    }
-                    return result;
-                }
-            }
-        }
-        return null;
-    }
-
-    public static byte[] toNullableByteArray(byte[] array) {
-        return array == null ? NULL_BYTE_ARRAY : array;
-    }
-
-    public static byte[] fromNullableByteArray(byte[] array) {
-        return array == NULL_BYTE_ARRAY ? null : array;
-    }
-
-    private static int nullSafeLength(byte[] array) {
+    public static int nullSafeLength(byte[] array) {
         return array == null ? -1 : array.length;
     }
 
-    public void putCached(String transName, String transformedName, byte[] preTransformBytes, byte[] result) {
-        synchronized (transformerMap) {
-            TransformerData data = transformerMap.get(transName);
-            if (data == null) {
-                transformerMap.put(transName, data = new TransformerData(transName));
-            }
-            CachedTransformation cached = new CachedTransformation(
-                transformedName,
-                preTransformBytes,
-                nullSafeLength(preTransformBytes),
-                result);
-            if (cached.isValid()) {
-                data.transformationMap.put(transformedName, cached);
-            }
-        }
-    }
-
-    private static int calculateHash(byte[] data) {
+    public static int calculateHash(byte[] data) {
         return calculateHash(data, nullSafeLength(data));
     }
 
@@ -372,11 +323,6 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         memo.data = data;
         memo.value = hash;
         return hash;
-    }
-
-    private static int now() {
-        // TODO update the format in 6055
-        return (int) (System.currentTimeMillis() / 1000 / 60);
     }
 
     @EqualsAndHashCode
@@ -427,7 +373,12 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
                 if (preHash != postHash) {
                     diff = generateDiff(source, sourceLen, target, targetClassName);
                 }
-                this.lastAccessed = now();
+                this.updateAccessTime();
+            }
+
+            public void updateAccessTime() {
+                // TODO update the format in 6055
+                this.lastAccessed = (int) (System.currentTimeMillis() / 1000 / 60);
             }
 
             private static final ThreadLocal<Delta> deltaThreadLocal = ThreadLocal.withInitial(Delta::new);

--- a/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
+++ b/src/main/java/makamys/coretweaks/optimization/transformercache/lite/TransformerCache.java
@@ -102,8 +102,6 @@ public class TransformerCache implements IModEventListener, ITransformerWrapperP
         transformersToCache = Sets.newHashSet(Config.transformersToCache.get());
 
         // We get a ClassCircularityError if we don't add these
-        Launch.classLoader
-            .addTransformerExclusion("makamys.coretweaks.optimization.transformercache.lite.TransformerCache");
         Launch.classLoader.addTransformerExclusion("makamys.coretweaks.util.InMemoryGDiffPatcher");
         Launch.classLoader.addTransformerExclusion("makamys.coretweaks.util.FastByteBufferSeekableSource");
 


### PR DESCRIPTION
Now the `TransformerCache` class actually handles the cache loading and saving. And the `CachedTransformerWrapper` class handles the transformation.
Also fixed some bugs :
- now the transformer cache properly stops after it has been saved during runtime and doesn't start growing again
- properly write the cache miss/runs in the csv file